### PR TITLE
Service accounts need to be set for each namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ source 'https://rubygems.org'
 
 gem 'kitchen-terraform', '7.0.2'
 
+# GCP InSpec Bug: https://github.com/inspec/inspec-gcp/issues/596
+
+gem 'nori', '2.6.0'
+
 # These Gems are used by the Shopify/ruby-lsp Visual Studio Code extension
 
 gem 'rubocop', '1.25.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -504,8 +504,7 @@ GEM
     net-ssh (7.2.1)
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
-    nori (2.7.0)
-      bigdecimal
+    nori (2.6.0)
     options (2.3.2)
     os (1.1.4)
     parallel (1.24.0)
@@ -761,6 +760,7 @@ PLATFORMS
 
 DEPENDENCIES
   kitchen-terraform (= 7.0.2)
+  nori (= 2.6.0)
   rubocop (= 1.25.1)
   ruby-lsp (= 0.14.6)
 

--- a/global/README.md
+++ b/global/README.md
@@ -23,9 +23,9 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_compute_global_address.istio_gateway_mci](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
-| [google_compute_managed_ssl_certificate.istio_gateway](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_managed_ssl_certificate) | resource |
+| [google_compute_managed_ssl_certificate.istio_gateway_mci](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_managed_ssl_certificate) | resource |
 | [google_compute_ssl_policy.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_ssl_policy) | resource |
-| [google_dns_record_set.istio_gateway](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
+| [google_dns_record_set.istio_gateway_mci](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
 | [google_project_iam_member.container_deployer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.gke_hub_service_agent](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.host_project_network_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
@@ -41,17 +41,17 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_gke_fleet_host_project_id"></a> [gke\_fleet\_host\_project\_id](#input\_gke\_fleet\_host\_project\_id) | The project ID of the GKE Hub host project | `string` | `""` | no |
-| <a name="input_google_service_account"></a> [google\_service\_account](#input\_google\_service\_account) | The email address of the pre-existing Google service account to use for the namespace administrator | `string` | n/a | yes |
 | <a name="input_istio_gateway_mci_dns"></a> [istio\_gateway\_mci\_dns](#input\_istio\_gateway\_mci\_dns) | Map of attributes for the Istio gateway multi-cluster ingress domain names, it is also used to create the managed certificate resource | <pre>map(object({<br>    managed_zone = string<br>    project      = string<br>  }))</pre> | `{}` | no |
-| <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | A map of namespaces | <pre>map(object({<br>    istio_injection = optional(string, "disabled")<br>  }))</pre> | `{}` | no |
+| <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | A map of namespaces with the Google service account used for the namespace administrator and whether Istio injection is enabled or disabled | <pre>map(object({<br>    google_service_account = string<br>    istio_injection        = optional(string, "disabled")<br>  }))</pre> | `{}` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project in which the resource belongs | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_container_deployer_service_accounts"></a> [container\_deployer\_service\_accounts](#output\_container\_deployer\_service\_accounts) | The service accounts for the container deployer |
 | <a name="output_gke_fleet_host_project_number"></a> [gke\_fleet\_host\_project\_number](#output\_gke\_fleet\_host\_project\_number) | The project number of the fleet host project |
-| <a name="output_istio_gateway_mci_ip"></a> [istio\_gateway\_mci\_ip](#output\_istio\_gateway\_mci\_ip) | The IP address for the Istio Gateway multi-cluster ingress |
-| <a name="output_istio_gateway_ssl_certificate_name"></a> [istio\_gateway\_ssl\_certificate\_name](#output\_istio\_gateway\_ssl\_certificate\_name) | The name of the SSL certificate for the Istio Gateway |
+| <a name="output_istio_gateway_mci_global_address"></a> [istio\_gateway\_mci\_global\_address](#output\_istio\_gateway\_mci\_global\_address) | The IP address for the Istio Gateway multi-cluster ingress |
+| <a name="output_istio_gateway_mci_ssl_certificate_name"></a> [istio\_gateway\_mci\_ssl\_certificate\_name](#output\_istio\_gateway\_mci\_ssl\_certificate\_name) | The name of the SSL certificate for the Istio Gateway multi-cluster ingress |
 | <a name="output_workload_identity_service_account_emails"></a> [workload\_identity\_service\_account\_emails](#output\_workload\_identity\_service\_account\_emails) | The email addresses of the service accounts for the Kubernetes namespace workload identity |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/global/locals.tf
+++ b/global/locals.tf
@@ -3,5 +3,9 @@
 
 
 locals {
+  container_deployer_service_accounts = toset(distinct([
+    for k in values(var.namespaces) : k.google_service_account
+  ]))
+
   istio_gateway_domains = keys(var.istio_gateway_mci_dns)
 }

--- a/global/outputs.tf
+++ b/global/outputs.tf
@@ -1,14 +1,19 @@
 # Output Values
 # https://www.terraform.io/language/values/outputs
 
-output "istio_gateway_mci_ip" {
+output "container_deployer_service_accounts" {
+  description = "The service accounts for the container deployer"
+  value       = local.container_deployer_service_accounts
+}
+
+output "istio_gateway_mci_global_address" {
   description = "The IP address for the Istio Gateway multi-cluster ingress"
   value       = var.gke_fleet_host_project_id == "" ? google_compute_global_address.istio_gateway_mci[0].address : ""
 }
 
-output "istio_gateway_ssl_certificate_name" {
-  description = "The name of the SSL certificate for the Istio Gateway"
-  value       = var.gke_fleet_host_project_id == "" ? google_compute_managed_ssl_certificate.istio_gateway[0].name : ""
+output "istio_gateway_mci_ssl_certificate_name" {
+  description = "The name of the SSL certificate for the Istio Gateway multi-cluster ingress"
+  value       = var.gke_fleet_host_project_id == "" ? google_compute_managed_ssl_certificate.istio_gateway_mci[0].name : ""
 }
 
 output "gke_fleet_host_project_number" {

--- a/global/variables.tf
+++ b/global/variables.tf
@@ -7,23 +7,14 @@ variable "gke_fleet_host_project_id" {
   default     = ""
 }
 
-variable "google_service_account" {
-  description = "The email address of the pre-existing Google service account to use for the namespace administrator"
-  type        = string
-}
-
 variable "namespaces" {
-  description = "A map of namespaces"
+  description = "A map of namespaces with the Google service account used for the namespace administrator and whether Istio injection is enabled or disabled"
   default     = {}
 
   type = map(object({
-    istio_injection = optional(string, "disabled")
+    google_service_account = string
+    istio_injection        = optional(string, "disabled")
   }))
-
-  validation {
-    condition     = alltrue([for k in keys(var.namespaces) : length(k) <= 20])
-    error_message = "Each namespace name must not contain more than 20 characters."
-  }
 }
 
 variable "istio_gateway_mci_dns" {

--- a/infracost.yml
+++ b/infracost.yml
@@ -21,6 +21,9 @@ projects:
     - path: test/fixtures/gke_fleet_host/gke_fleet_host/regional_onboarding
       name: gke_fleet_host_regional_onboarding
       usage_file: test/fixtures/gke_fleet_host/gke_fleet_host/regional_onboarding/infracost-usage.yml
+    - path: test/fixtures/gke_fleet_host/gke_fleet_host/shared
+      name: gke_fleet_host_shared
+      usage_file: test/fixtures/gke_fleet_host/gke_fleet_host/shared/infracost-usage.yml
     - path: test/fixtures/gke_fleet_member/gke_fleet_member/global
       name: gke_fleet_host_global
       usage_file: test/fixtures/gke_fleet_member/gke_fleet_member/global/infracost-usage.yml

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -27,6 +27,10 @@ suites:
         - name: inspec_gcp
           backend: gcp
           controls:
+            - compute_global_address
+            - compute_ssl_certificate
+            - compute_ssl_policy
+            - dns_resource_record_set
             - project_iam_binding
 
   - name: gke_fleet_host_regional
@@ -42,7 +46,6 @@ suites:
             - kms_crypto_key
             - project_iam_binding
             - service_account
-            - service_account_key
 
   - name: gke_fleet_host_regional_onboarding
     transport:

--- a/regional/README.md
+++ b/regional/README.md
@@ -11,8 +11,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.20.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 5.20.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.16.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 5.16.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
 
 ## Modules

--- a/regional/istio/README.md
+++ b/regional/istio/README.md
@@ -11,9 +11,9 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.20.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.17.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.12.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.27.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.26.0 |
 
 ## Modules
 

--- a/regional/mci/README.md
+++ b/regional/mci/README.md
@@ -30,7 +30,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_istio_gateway_mci_ip"></a> [istio\_gateway\_mci\_ip](#input\_istio\_gateway\_mci\_ip) | The IP address for the Istio Gateway multi-cluster ingress | `string` | `""` | no |
+| <a name="input_istio_gateway_mci_global_address"></a> [istio\_gateway\_mci\_global\_address](#input\_istio\_gateway\_mci\_global\_address) | The IP address for the Istio Gateway multi-cluster ingress | `string` | `""` | no |
 | <a name="input_multi_cluster_service_clusters"></a> [multi\_cluster\_service\_clusters](#input\_multi\_cluster\_service\_clusters) | List of clusters to be included in the MultiClusterService | <pre>list(object({<br>    link = string<br>  }))</pre> | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project in which the resource belongs | `string` | n/a | yes |
 

--- a/regional/mci/main.tf
+++ b/regional/mci/main.tf
@@ -12,7 +12,7 @@ resource "kubernetes_manifest" "istio_gateway_mci" {
       annotations = {
         "networking.gke.io/frontend-config"  = kubernetes_manifest.istio_gateway_mci_frontendconfig.manifest.metadata.name
         "networking.gke.io/pre-shared-certs" = "istio-gateway"
-        "networking.gke.io/static-ip"        = var.istio_gateway_mci_ip
+        "networking.gke.io/static-ip"        = var.istio_gateway_mci_global_address
       }
     }
 

--- a/regional/mci/variables.tf
+++ b/regional/mci/variables.tf
@@ -1,7 +1,7 @@
 # Input Variables
 # https://www.terraform.io/language/values/variables
 
-variable "istio_gateway_mci_ip" {
+variable "istio_gateway_mci_global_address" {
   description = "The IP address for the Istio Gateway multi-cluster ingress"
   type        = string
   default     = ""

--- a/regional/onboarding/README.md
+++ b/regional/onboarding/README.md
@@ -32,8 +32,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_google_service_account"></a> [google\_service\_account](#input\_google\_service\_account) | The email address of the pre-existing Google service account to use for the namespace administrator | `string` | n/a | yes |
-| <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | A map of namespaces | <pre>map(object({<br>    istio_injection = optional(string, "disabled")<br>  }))</pre> | n/a | yes |
+| <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | A map of namespaces with the Google service account used for the namespace administrator and whether Istio injection is enabled or disabled | <pre>map(object({<br>    google_service_account = string<br>    istio_injection        = optional(string, "disabled")<br>  }))</pre> | `{}` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project in which the resource belongs | `string` | n/a | yes |
 | <a name="input_workload_identity_service_account_emails"></a> [workload\_identity\_service\_account\_emails](#input\_workload\_identity\_service\_account\_emails) | A map of workload identity service account emails for each namespace. Each key should be a namespace name, and the value should be the email address of the service account to associate with that namespace. | `map(string)` | n/a | yes |
 

--- a/regional/onboarding/locals.tf
+++ b/regional/onboarding/locals.tf
@@ -1,2 +1,11 @@
 # Local Values
 # https://www.terraform.io/docs/language/values/locals.html
+
+locals {
+  namespace_admin_service_accounts = {
+    for k, v in var.namespaces : "${k}:${v.google_service_account}" => {
+      namespace       = k,
+      service_account = v.google_service_account
+    }
+  }
+}

--- a/regional/onboarding/main.tf
+++ b/regional/onboarding/main.tf
@@ -46,11 +46,11 @@ resource "kubernetes_role_v1" "namespace_admin" {
 # https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding_v1
 
 resource "kubernetes_role_binding_v1" "namespace_admin" {
-  for_each = var.namespaces
+  for_each = local.namespace_admin_service_accounts
 
   metadata {
     name      = "namespace-admin"
-    namespace = kubernetes_namespace_v1.this[each.key].metadata.0.name
+    namespace = kubernetes_namespace_v1.this[each.value.namespace].metadata.0.name
   }
 
   role_ref {
@@ -61,7 +61,7 @@ resource "kubernetes_role_binding_v1" "namespace_admin" {
 
   subject {
     kind = "User"
-    name = data.google_service_account.workload_identity[each.key].email
+    name = each.value.service_account
   }
 }
 

--- a/regional/onboarding/variables.tf
+++ b/regional/onboarding/variables.tf
@@ -1,16 +1,13 @@
 # Input Variables
 # https://www.terraform.io/language/values/variables
 
-variable "google_service_account" {
-  description = "The email address of the pre-existing Google service account to use for the namespace administrator"
-  type        = string
-}
-
 variable "namespaces" {
-  description = "A map of namespaces"
+  description = "A map of namespaces with the Google service account used for the namespace administrator and whether Istio injection is enabled or disabled"
+  default     = {}
 
   type = map(object({
-    istio_injection = optional(string, "disabled")
+    google_service_account = string
+    istio_injection        = optional(string, "disabled")
   }))
 }
 

--- a/test/fixtures/gke_fleet_host/global/main.tf
+++ b/test/fixtures/gke_fleet_host/global/main.tf
@@ -5,7 +5,6 @@ module "test" {
 
   source = "../../../../global"
 
-  google_service_account = var.google_service_account
 
   istio_gateway_mci_dns = {
     "gateway.test.gcp.osinfra.io" = {
@@ -20,19 +19,24 @@ module "test" {
   }
 
   namespaces = {
-    bar = {
-      istio_injection = "disabled"
+    gke-java-example = {
+      google_service_account = var.google_service_account
+      istio_injection        = "disabled"
     }
 
-    foo = {
-      istio_injection = "enabled"
+    gke-go-example = {
+      google_service_account = var.google_service_account
+      istio_injection        = "disabled"
     }
 
     istio-ingress = {
-      istio_injection = "enabled"
+      google_service_account = var.google_service_account
+      istio_injection        = "enabled"
     }
 
-    istio-system = {}
+    istio-system = {
+      google_service_account = var.google_service_account
+    }
   }
 
   project_id = var.project_id

--- a/test/fixtures/gke_fleet_host/global/outputs.tf
+++ b/test/fixtures/gke_fleet_host/global/outputs.tf
@@ -1,12 +1,16 @@
 # Output Values
 # https://www.terraform.io/language/values/outputs
 
-output "istio_gateway_mci_ip" {
-  value = module.test.istio_gateway_mci_ip
+output "container_deployer_service_accounts" {
+  value = module.test.container_deployer_service_accounts
 }
 
-output "istio_gateway_ssl_certificate_name" {
-  value = module.test.istio_gateway_ssl_certificate_name
+output "istio_gateway_mci_global_address" {
+  value = module.test.istio_gateway_mci_global_address
+}
+
+output "istio_gateway_mci_ssl_certificate_name" {
+  value = module.test.istio_gateway_mci_ssl_certificate_name
 }
 
 output "project_id" {

--- a/test/fixtures/gke_fleet_host/regional_mci/main.tf
+++ b/test/fixtures/gke_fleet_host/regional_mci/main.tf
@@ -47,7 +47,7 @@ module "test" {
 
   source = "../../../../regional/mci"
 
-  istio_gateway_mci_ip = local.global.istio_gateway_mci_ip
+  istio_gateway_mci_global_address = local.global.istio_gateway_mci_global_address
 
   multi_cluster_service_clusters = [
     {

--- a/test/fixtures/gke_fleet_host/regional_onboarding/main.tf
+++ b/test/fixtures/gke_fleet_host/regional_onboarding/main.tf
@@ -47,23 +47,27 @@ module "test" {
 
   source = "../../../../regional/onboarding"
 
-  google_service_account = "plt-lz-testing-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com"
 
   namespaces = {
 
-    bar = {
-      istio_injection = "disabled"
+    gke-java-example = {
+      google_service_account = var.google_service_account
+      istio_injection        = "disabled"
     }
 
-    foo = {
-      istio_injection = "enabled"
+    gke-go-example = {
+      google_service_account = var.google_service_account
+      istio_injection        = "disabled"
     }
 
     istio-ingress = {
-      istio_injection = "enabled"
+      google_service_account = var.google_service_account
+      istio_injection        = "enabled"
     }
 
-    istio-system = {}
+    istio-system = {
+      google_service_account = var.google_service_account
+    }
   }
 
   project_id = var.project_id
@@ -78,8 +82,8 @@ module "test" {
 resource "kubernetes_job_v1" "test" {
   for_each = toset(
     [
-      "foo",
-      "bar"
+      "gke-go-example",
+      "gke-java-example"
     ]
   )
 

--- a/test/fixtures/gke_fleet_host/regional_onboarding/variables.tf
+++ b/test/fixtures/gke_fleet_host/regional_onboarding/variables.tf
@@ -6,6 +6,11 @@ variable "gke_fleet_host_project_id" {
   default = "test-gke-fleet-host-tf64-sb"
 }
 
+variable "google_service_account" {
+  type    = string
+  default = "plt-lz-testing-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com"
+}
+
 variable "project_id" {
   type    = string
   default = "test-gke-fleet-host-tf64-sb"

--- a/test/fixtures/gke_fleet_member/global/main.tf
+++ b/test/fixtures/gke_fleet_member/global/main.tf
@@ -6,6 +6,12 @@ module "test" {
   source = "../../../../global"
 
   gke_fleet_host_project_id = var.gke_fleet_host_project_id
-  google_service_account    = var.google_service_account
-  project_id                = var.project_id
+
+  namespaces = {
+    istio-system = {
+      google_service_account = "plt-lz-testing-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com"
+    }
+  }
+
+  project_id = var.project_id
 }

--- a/test/fixtures/gke_fleet_member/regional_onboarding/main.tf
+++ b/test/fixtures/gke_fleet_member/regional_onboarding/main.tf
@@ -47,10 +47,11 @@ module "test" {
 
   source = "../../../../regional/onboarding"
 
-  google_service_account = "plt-lz-testing-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com"
 
   namespaces = {
-    istio-system = {}
+    istio-system = {
+      google_service_account = "plt-lz-testing-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com"
+    }
   }
 
   project_id = var.project_id

--- a/test/integration/gke_fleet_host_global/controls/gcp_inspec.rb
+++ b/test/integration/gke_fleet_host_global/controls/gcp_inspec.rb
@@ -1,7 +1,57 @@
 # Chef InSpec
 # https://www.chef.io/inspec
 
+container_deployer_service_accounts = input('container_deployer_service_accounts')
 project_id = input('project_id')
+
+control 'compute_global_address' do
+  title 'Compute Global Address'
+
+  # Compute Global Address Resource
+  # https://www.inspec.io/docs/reference/resources/google_compute_global_address
+
+  describe google_compute_global_address(project: project_id, name: 'istio-gateway-mci') do
+    it { should exist }
+    its('address_type') { should eq 'EXTERNAL' }
+  end
+end
+
+control 'compute_ssl_certificate' do
+  title 'Compute SSL Certificate'
+
+  # Compute SSL Certificate Resource
+  # https://www.inspec.io/docs/reference/resources/google_compute_ssl_certificate
+
+  describe google_compute_ssl_certificate(project: project_id, name: 'istio-gateway-mci') do
+    it { should exist }
+  end
+end
+
+control 'compute_ssl_policy' do
+  title 'Compute SSL Policy'
+
+  # Compute SSL Policy Resource
+  # https://www.inspec.io/docs/reference/resources/google_compute_ssl_policy
+
+  describe google_compute_ssl_policy(project: project_id, name: 'default') do
+    it { should exist }
+  end
+end
+
+control 'dns_resource_record_set' do
+  title 'DNS Record Set'
+
+  # DNS Resource Record Set Resource
+  # https://www.inspec.io/docs/reference/resources/google_dns_resource_record_set
+
+  ['gateway.test.gcp.osinfra.io', 'stream-team.test.gcp.osinfra.io'].each do |record|
+    describe google_dns_resource_record_set(project: 'test-vpc-host-tf12-sb', managed_zone: 'test-gcp-osinfra-io',
+                                            name: "#{record}.", type: 'A') do
+      it { should exist }
+      its('type') { should eq 'A' }
+    end
+  end
+end
 
 control 'project_iam_binding' do
   title 'Project IAM Binding'
@@ -13,6 +63,14 @@ control 'project_iam_binding' do
     it { should exist }
     its('members') do
       should include "serviceAccount:#{project_id}.svc.id.goog[gke-mcs/gke-mcs-importer]"
+    end
+  end
+
+  container_deployer_service_accounts.each do |service_account|
+    describe google_project_iam_binding(project: project_id,
+                                        role: 'organizations/163313809793/roles/container.deployer') do
+      it { should exist }
+      its('members') { should include "serviceAccount:#{service_account}" }
     end
   end
 end

--- a/test/integration/shared/inspec.yml
+++ b/test/integration/shared/inspec.yml
@@ -13,4 +13,4 @@ name: InSpec GCP (Google Cloud Platform) Resource Pack
 
 depends:
   - name: inspec_gcp
-    url: https://github.com/inspec/inspec-gcp/archive/v1.11.93.tar.gz
+    url: https://github.com/inspec/inspec-gcp/archive/v1.11.94.tar.gz


### PR DESCRIPTION
Fixes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new local variable for container deployer service accounts.
	- Added a new resource for Google Compute SSL policy.
	- Implemented new controls in the testing suite for better resource validation.
- **Bug Fixes**
	- Addressed a bug related to GCP InSpec by adjusting the `nori` gem version.
- **Documentation**
	- Updated READMEs across various modules with revised resource names, version numbers, and input/output descriptions.
	- Enhanced documentation to include Google service account information in the `namespaces` variable.
- **Refactor**
	- Renamed resources and variables related to Istio Gateway and IP addresses for clarity.
	- Restructured the `namespaces` variable and related assignments for improved clarity and functionality.
- **Chores**
	- Modified the Infracost configuration to include a new entry for project cost estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->