### PR TITLE
Rename Istio gateway DNS variable

### DIFF
--- a/global/README.md
+++ b/global/README.md
@@ -41,7 +41,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_gke_fleet_host_project_id"></a> [gke\_fleet\_host\_project\_id](#input\_gke\_fleet\_host\_project\_id) | The project ID of the GKE Hub host project | `string` | `""` | no |
-| <a name="input_istio_gateway_mci_dns"></a> [istio\_gateway\_mci\_dns](#input\_istio\_gateway\_mci\_dns) | Map of attributes for the Istio gateway multi-cluster ingress domain names, it is also used to create the managed certificate resource | <pre>map(object({<br>    managed_zone = string<br>    project      = string<br>  }))</pre> | `{}` | no |
+| <a name="input_istio_gateway_dns"></a> [istio\_gateway\_dns](#input\_istio\_gateway\_dns) | Map of attributes for the Istio gateway domain names, it is also used to create the managed certificate resource | <pre>map(object({<br>    managed_zone = string<br>    project      = string<br>  }))</pre> | `{}` | no |
 | <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | A map of namespaces with the Google service account used for the namespace administrator and whether Istio injection is enabled or disabled | <pre>map(object({<br>    google_service_account = string<br>    istio_injection        = optional(string, "disabled")<br>  }))</pre> | `{}` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project in which the resource belongs | `string` | n/a | yes |
 

--- a/global/locals.tf
+++ b/global/locals.tf
@@ -7,5 +7,5 @@ locals {
     for k in values(var.namespaces) : k.google_service_account
   ]))
 
-  istio_gateway_domains = keys(var.istio_gateway_mci_dns)
+  istio_gateway_domains = keys(var.istio_gateway_dns)
 }

--- a/global/main.tf
+++ b/global/main.tf
@@ -50,7 +50,7 @@ resource "google_compute_ssl_policy" "default" {
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set
 
 resource "google_dns_record_set" "istio_gateway_mci" {
-  for_each = var.istio_gateway_mci_dns
+  for_each = var.istio_gateway_dns
 
   managed_zone = each.value.managed_zone
   name         = "${each.key}."

--- a/global/variables.tf
+++ b/global/variables.tf
@@ -17,8 +17,8 @@ variable "namespaces" {
   }))
 }
 
-variable "istio_gateway_mci_dns" {
-  description = "Map of attributes for the Istio gateway multi-cluster ingress domain names, it is also used to create the managed certificate resource"
+variable "istio_gateway_dns" {
+  description = "Map of attributes for the Istio gateway domain names, it is also used to create the managed certificate resource"
   type = map(object({
     managed_zone = string
     project      = string

--- a/infracost.yml
+++ b/infracost.yml
@@ -21,9 +21,6 @@ projects:
     - path: test/fixtures/gke_fleet_host/gke_fleet_host/regional_onboarding
       name: gke_fleet_host_regional_onboarding
       usage_file: test/fixtures/gke_fleet_host/gke_fleet_host/regional_onboarding/infracost-usage.yml
-    - path: test/fixtures/gke_fleet_host/gke_fleet_host/shared
-      name: gke_fleet_host_shared
-      usage_file: test/fixtures/gke_fleet_host/gke_fleet_host/shared/infracost-usage.yml
     - path: test/fixtures/gke_fleet_member/gke_fleet_member/global
       name: gke_fleet_host_global
       usage_file: test/fixtures/gke_fleet_member/gke_fleet_member/global/infracost-usage.yml

--- a/regional/istio/README.md
+++ b/regional/istio/README.md
@@ -42,8 +42,8 @@ No modules.
 | <a name="input_enable_istio_gateway"></a> [enable\_istio\_gateway](#input\_enable\_istio\_gateway) | Enable the Istio gateway, used for ingress traffic into the mesh | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment suffix for example: `sb` (Sandbox), `nonprod` (Non-Production), `prod` (Production) | `string` | `"sb"` | no |
 | <a name="input_gateway_autoscale_min"></a> [gateway\_autoscale\_min](#input\_gateway\_autoscale\_min) | The minimum number of gateway replicas to run | `number` | `1` | no |
-| <a name="input_ingress_istio_gateway_dns"></a> [ingress\_istio\_gateway\_dns](#input\_ingress\_istio\_gateway\_dns) | Map of attributes for the ingress Istio gateway domain names, it is also used to create the managed certificate resource | <pre>map(object({<br>    managed_zone = string<br>    project      = string<br>  }))</pre> | `{}` | no |
 | <a name="input_istio_chart_repository"></a> [istio\_chart\_repository](#input\_istio\_chart\_repository) | The repository to pull the Istio Helm chart from | `string` | `"https://istio-release.storage.googleapis.com/charts"` | no |
+| <a name="input_istio_gateway_dns"></a> [istio\_gateway\_dns](#input\_istio\_gateway\_dns) | Map of attributes for the Istio gateway domain names, it is also used to create the managed certificate resource | <pre>map(object({<br>    managed_zone = string<br>    project      = string<br>  }))</pre> | `{}` | no |
 | <a name="input_istio_version"></a> [istio\_version](#input\_istio\_version) | The version of istio to install | `string` | `"1.20.3"` | no |
 | <a name="input_pilot_autoscale_min"></a> [pilot\_autoscale\_min](#input\_pilot\_autoscale\_min) | The minimum number of pilot replicas to run | `number` | `1` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project in which the resource belongs | `string` | n/a | yes |

--- a/regional/istio/locals.tf
+++ b/regional/istio/locals.tf
@@ -10,7 +10,7 @@ locals {
     }
   EOF
 
-  istio_gateway_domains = keys(var.ingress_istio_gateway_dns)
+  istio_gateway_domains = keys(var.istio_gateway_dns)
 
   multi_cluster_name = "${var.cluster_prefix}-${var.region}-${var.environment}"
 }

--- a/regional/istio/main.tf
+++ b/regional/istio/main.tf
@@ -13,7 +13,7 @@ resource "google_compute_global_address" "istio_gateway" {
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set
 
 resource "google_dns_record_set" "istio_gateway" {
-  for_each = var.ingress_istio_gateway_dns
+  for_each = var.istio_gateway_dns
 
   managed_zone = each.value.managed_zone
   name         = "${each.key}."

--- a/regional/istio/variables.tf
+++ b/regional/istio/variables.tf
@@ -33,8 +33,8 @@ variable "istio_chart_repository" {
   default     = "https://istio-release.storage.googleapis.com/charts"
 }
 
-variable "ingress_istio_gateway_dns" {
-  description = "Map of attributes for the ingress Istio gateway domain names, it is also used to create the managed certificate resource"
+variable "istio_gateway_dns" {
+  description = "Map of attributes for the Istio gateway domain names, it is also used to create the managed certificate resource"
   type = map(object({
     managed_zone = string
     project      = string

--- a/test/fixtures/gke_fleet_host/global/main.tf
+++ b/test/fixtures/gke_fleet_host/global/main.tf
@@ -6,7 +6,7 @@ module "test" {
   source = "../../../../global"
 
 
-  istio_gateway_mci_dns = {
+  istio_gateway_dns = {
     "gateway.test.gcp.osinfra.io" = {
       managed_zone = "test-gcp-osinfra-io"
       project      = var.dns_project_id

--- a/test/fixtures/gke_fleet_host/regional_istio/main.tf
+++ b/test/fixtures/gke_fleet_host/regional_istio/main.tf
@@ -56,7 +56,7 @@ module "test" {
   cluster_prefix       = "fleet-host"
   enable_istio_gateway = true
 
-  ingress_istio_gateway_dns = {
+  istio_gateway_dns = {
     "gateway-us-east1.test.gcp.osinfra.io" = {
       managed_zone = "test-gcp-osinfra-io"
       project      = var.dns_project_id


### PR DESCRIPTION
[skip actions]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified Istio gateway domain names configuration by renaming variables across global and regional settings.
- **Chores**
	- Updated documentation to reflect variable name changes.
	- Adjusted project naming in infrastructural configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->