### PR TITLE
Support for Istio service mesh manifests

### DIFF
--- a/regional/istio/README.md
+++ b/regional/istio/README.md
@@ -64,6 +64,7 @@ No modules.
 | <a name="input_istio_remote_injection_path"></a> [istio\_remote\_injection\_path](#input\_istio\_remote\_injection\_path) | The sidecar injector mutating webhook configuration path value for the clientConfig.service field | `string` | `"/inject"` | no |
 | <a name="input_istio_remote_injection_url"></a> [istio\_remote\_injection\_url](#input\_istio\_remote\_injection\_url) | The sidecar injector mutating webhook configuration clientConfig.url value | `string` | `""` | no |
 | <a name="input_istio_version"></a> [istio\_version](#input\_istio\_version) | The version of istio to install | `string` | `"1.22.2"` | no |
+| <a name="input_node_location"></a> [node\_location](#input\_node\_location) | The zone in which the cluster's nodes should be located. If not specified, the cluster's nodes are located across zones in the region | `string` | `null` | no |
 | <a name="input_project"></a> [project](#input\_project) | The ID of the project in which the resource belongs | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region to deploy the resources into | `string` | n/a | yes |
 

--- a/regional/istio/helm/istiod.yml
+++ b/regional/istio/helm/istiod.yml
@@ -1,6 +1,6 @@
 global:
   proxy:
-    tracer: none
+    tracer: datadog
 
   meshID: default
   network: standard-shared

--- a/regional/istio/helm/istiod.yml
+++ b/regional/istio/helm/istiod.yml
@@ -1,6 +1,6 @@
 global:
   proxy:
-    tracer: datadog
+    tracer: none
 
   meshID: default
   network: standard-shared

--- a/regional/istio/locals.tf
+++ b/regional/istio/locals.tf
@@ -11,6 +11,6 @@ locals {
   EOF
 
   istio_gateway_domains = keys(var.istio_gateway_dns)
-
-  multi_cluster_name = "${var.cluster_prefix}-${var.region}-${var.environment}"
+  name                  = var.node_location == null ? var.region : "${var.region}-${var.node_location}"
+  multi_cluster_name    = "${var.cluster_prefix}-${var.region}-${var.environment}"
 }

--- a/regional/istio/manifests/README.md
+++ b/regional/istio/manifests/README.md
@@ -1,0 +1,44 @@
+# Terraform Documentation
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.31.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubernetes_manifest.gke_info_istio_virtual_services](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.istio_cluster_services_destination_rule](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.istio_gateway](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.istio_kubernetes_default_destination_rule](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.istio_peer_authentication](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.istio_virtual_services](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_common_gke_info_istio_virtual_services"></a> [common\_gke\_info\_istio\_virtual\_services](#input\_common\_gke\_info\_istio\_virtual\_services) | The map of Istio VirtualServices to create for GKE Info, that are common among all regions | <pre>map(object({<br>    destination_host = string<br>    host             = string<br>  }))</pre> | n/a | yes |
+| <a name="input_common_istio_virtual_services"></a> [common\_istio\_virtual\_services](#input\_common\_istio\_virtual\_services) | The map of Istio VirtualServices to create, that are common among all regions | <pre>map(object({<br>    destination_host = string<br>    destination_port = optional(number, 8080)<br>    host             = string<br>  }))</pre> | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment suffix for example: `sb` (Sandbox), `nonprod` (Non-Production), `prod` (Production) | `string` | `"sb"` | no |
+| <a name="input_gke_info_istio_virtual_services"></a> [gke\_info\_istio\_virtual\_services](#input\_gke\_info\_istio\_virtual\_services) | The map of Istio VirtualServices to create for GKE Info | <pre>map(object({<br>    destination_host = string<br>    host             = string<br>  }))</pre> | n/a | yes |
+| <a name="input_istio_failover_from_region"></a> [istio\_failover\_from\_region](#input\_istio\_failover\_from\_region) | The region to failover from | `string` | `""` | no |
+| <a name="input_istio_failover_to_region"></a> [istio\_failover\_to\_region](#input\_istio\_failover\_to\_region) | The region to failover to | `string` | `""` | no |
+| <a name="input_istio_virtual_services"></a> [istio\_virtual\_services](#input\_istio\_virtual\_services) | The map of Istio VirtualServices to create, that are unique to a region | <pre>map(object({<br>    destination_host = string<br>    destination_port = optional(number, 8080)<br>    host             = string<br>  }))</pre> | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/regional/istio/manifests/main.tf
+++ b/regional/istio/manifests/main.tf
@@ -1,0 +1,217 @@
+# Kubernetes Manifest Resource
+# https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest
+
+resource "kubernetes_manifest" "istio_cluster_services_destination_rule" {
+  manifest = {
+    "apiVersion" = "networking.istio.io/v1beta1"
+    "kind"       = "DestinationRule"
+
+    "metadata" = {
+      "name"      = "cluster-services"
+      "namespace" = "istio-system"
+    }
+
+    "spec" = {
+      "host" = "*.svc.cluster.local"
+
+      "trafficPolicy" = {
+        "connectionPool" = {
+
+          # ConnectionPoolSettings
+          # https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-HTTPSettings
+
+          "http" = {
+            "maxRequestsPerConnection" = 0 # This is the default value
+          }
+        }
+
+        "loadBalancer" = {
+          "simple" = "LEAST_REQUEST"
+          "localityLbSetting" = {
+            "enabled" = true
+
+            "failover" = [
+              {
+                "from" = var.istio_failover_from_region
+                "to"   = var.istio_failover_to_region
+              }
+            ]
+          }
+        }
+
+        # OutlierDetection
+        # https://istio.io/latest/docs/reference/config/networking/destination-rule/#OutlierDetection
+
+        "outlierDetection" = {
+
+          # These are the default values
+
+          "consecutive5xxErrors" = 5
+          "interval"             = "10s"
+          "baseEjectionTime"     = "30s"
+          "maxEjectionPercent"   = 10
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_manifest" "istio_kubernetes_default_destination_rule" {
+  manifest = {
+    "apiVersion" = "networking.istio.io/v1beta1"
+    "kind"       = "DestinationRule"
+
+    "metadata" = {
+      "name"      = "kubernetes-default"
+      "namespace" = "istio-system"
+    }
+
+    "spec" = {
+      "host" = "kubernetes.default.svc"
+
+      "trafficPolicy" = {
+        "tls" = {
+          "mode" = "DISABLE"
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_manifest" "istio_gateway" {
+  manifest = {
+    "apiVersion" = "networking.istio.io/v1beta1"
+    "kind"       = "Gateway"
+
+    "metadata" = {
+      "name"      = "global"
+      "namespace" = "istio-ingress"
+    }
+
+    "spec" = {
+      "selector" = {
+        "istio" = "gateway"
+      }
+
+      "servers" = [
+        {
+          "port" = {
+            "name"     = "https"
+            "number"   = 443
+            "protocol" = "HTTPS"
+          }
+
+          "hosts" = [
+            "*"
+          ]
+
+          "tls" = {
+
+            # As part of the incoming TLS connection, the gateway will decrypt the traffic in order to apply the routing rules.
+
+            "mode"           = "SIMPLE"
+            "credentialName" = "gateway-tls"
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "kubernetes_manifest" "istio_peer_authentication" {
+  manifest = {
+    "apiVersion" = "security.istio.io/v1beta1"
+    "kind"       = "PeerAuthentication"
+
+    "metadata" = {
+      "name"      = "default"
+      "namespace" = "istio-system"
+    }
+
+    "spec" = {
+      "mtls" = {
+        "mode" = "STRICT"
+      }
+    }
+  }
+}
+
+resource "kubernetes_manifest" "istio_virtual_services" {
+  for_each = merge(var.istio_virtual_services, var.common_istio_virtual_services)
+
+  manifest = {
+    "apiVersion" = "networking.istio.io/v1beta1"
+    "kind"       = "VirtualService"
+
+    "metadata" = {
+      "name"      = each.key
+      "namespace" = "istio-system"
+    }
+
+    "spec" = {
+      "gateways" = [
+        kubernetes_manifest.istio_gateway.manifest.metadata.name
+      ]
+      "hosts" = [
+        each.value.host
+      ]
+
+      "http" = [
+        {
+          "route" = [
+            {
+              "destination" = {
+                "host" = each.value.destination_host
+                "port" = {
+                  "number" = each.value.destination_port
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+
+resource "kubernetes_manifest" "gke_info_istio_virtual_services" {
+  for_each = merge(var.gke_info_istio_virtual_services, var.common_gke_info_istio_virtual_services)
+
+  manifest = {
+    "apiVersion" = "networking.istio.io/v1beta1"
+    "kind"       = "VirtualService"
+    "metadata" = {
+      "name"      = each.key
+      "namespace" = "istio-ingress"
+    }
+    "spec" = {
+      "gateways" = [
+        kubernetes_manifest.istio_gateway.manifest.metadata.name
+      ]
+      "hosts" = [
+        each.value.host
+      ]
+      "http" = [
+        {
+          "match" = [
+            {
+              "uri" = {
+                "prefix" = "/gke-info"
+              }
+            }
+          ]
+          "route" = [
+            {
+              "destination" = {
+                "host" = each.value.destination_host
+                "port" = {
+                  "number" = 8080
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/regional/istio/manifests/main.tf
+++ b/regional/istio/manifests/main.tf
@@ -196,7 +196,7 @@ resource "kubernetes_manifest" "gke_info_istio_virtual_services" {
           "match" = [
             {
               "uri" = {
-                "prefix" = "/gke-info"
+                "prefix" = "/gke-info-go"
               }
             }
           ]

--- a/regional/istio/manifests/variables.tf
+++ b/regional/istio/manifests/variables.tf
@@ -1,0 +1,51 @@
+variable "common_gke_info_istio_virtual_services" {
+  description = "The map of Istio VirtualServices to create for GKE Info, that are common among all regions"
+  type = map(object({
+    destination_host = string
+    host             = string
+  }))
+}
+
+variable "common_istio_virtual_services" {
+  description = "The map of Istio VirtualServices to create, that are common among all regions"
+  type = map(object({
+    destination_host = string
+    destination_port = optional(number, 8080)
+    host             = string
+  }))
+}
+
+variable "environment" {
+  description = "The environment suffix for example: `sb` (Sandbox), `nonprod` (Non-Production), `prod` (Production)"
+  type        = string
+  default     = "sb"
+}
+
+variable "gke_info_istio_virtual_services" {
+  description = "The map of Istio VirtualServices to create for GKE Info"
+  type = map(object({
+    destination_host = string
+    host             = string
+  }))
+}
+
+variable "istio_failover_from_region" {
+  description = "The region to failover from"
+  type        = string
+  default     = ""
+}
+
+variable "istio_failover_to_region" {
+  description = "The region to failover to"
+  type        = string
+  default     = ""
+}
+
+variable "istio_virtual_services" {
+  description = "The map of Istio VirtualServices to create, that are unique to a region"
+  type = map(object({
+    destination_host = string
+    destination_port = optional(number, 8080)
+    host             = string
+  }))
+}

--- a/regional/istio/variables.tf
+++ b/regional/istio/variables.tf
@@ -156,6 +156,12 @@ variable "istio_version" {
   default     = "1.22.2"
 }
 
+variable "node_location" {
+  description = "The zone in which the cluster's nodes should be located. If not specified, the cluster's nodes are located across zones in the region"
+  type        = string
+  default     = null
+}
+
 variable "project" {
   description = "The ID of the project in which the resource belongs"
   type        = string

--- a/regional/onboarding/README.md
+++ b/regional/onboarding/README.md
@@ -11,6 +11,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | 5.36.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.31.0 |
 
 ## Modules
@@ -24,7 +25,10 @@ No modules.
 | [kubernetes_namespace_v1.istio_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [kubernetes_namespace_v1.istio_system](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [kubernetes_namespace_v1.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
+| [kubernetes_role_binding_v1.namespace_admin](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding_v1) | resource |
 | [kubernetes_role_v1.namespace_admin](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_v1) | resource |
+| [kubernetes_service_account_v1.workload_identity](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account_v1) | resource |
+| [google_service_account.workload_identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account) | data source |
 
 ## Inputs
 

--- a/regional/onboarding/main.tf
+++ b/regional/onboarding/main.tf
@@ -1,11 +1,11 @@
 # Google Service Account Data Source
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account
 
-# data "google_service_account" "workload_identity" {
-#   for_each = var.namespaces
+data "google_service_account" "workload_identity" {
+  for_each = var.namespaces
 
-#   account_id = var.workload_identity_service_account_emails[each.key]
-# }
+  account_id = var.workload_identity_service_account_emails[each.key]
+}
 
 # Kubernetes Namespace Resource
 # https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1
@@ -74,39 +74,39 @@ resource "kubernetes_role_v1" "namespace_admin" {
 # Kubernetes Role Binding Resource
 # https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding_v1
 
-# resource "kubernetes_role_binding_v1" "namespace_admin" {
-#   for_each = local.namespace_admin_service_accounts
+resource "kubernetes_role_binding_v1" "namespace_admin" {
+  for_each = local.namespace_admin_service_accounts
 
-#   metadata {
-#     name      = "namespace-admin"
-#     namespace = kubernetes_namespace_v1.this[each.value.namespace].metadata.0.name
-#   }
+  metadata {
+    name      = "namespace-admin"
+    namespace = kubernetes_namespace_v1.this[each.value.namespace].metadata.0.name
+  }
 
-#   role_ref {
-#     api_group = "rbac.authorization.k8s.io"
-#     kind      = "Role"
-#     name      = "namespace-admin"
-#   }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "namespace-admin"
+  }
 
-#   subject {
-#     kind = "User"
-#     name = each.value.service_account
-#   }
-# }
+  subject {
+    kind = "User"
+    name = each.value.service_account
+  }
+}
 
 # Kubernetes Service Account Resource
 # https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account_v1
 
-# resource "kubernetes_service_account_v1" "workload_identity" {
-#   for_each = var.namespaces
+resource "kubernetes_service_account_v1" "workload_identity" {
+  for_each = var.namespaces
 
-#   metadata {
+  metadata {
 
-#     annotations = {
-#       "iam.gke.io/gcp-service-account" = data.google_service_account.workload_identity[each.key].email
-#     }
+    annotations = {
+      "iam.gke.io/gcp-service-account" = data.google_service_account.workload_identity[each.key].email
+    }
 
-#     name      = "${each.key}-workload-identity-sa"
-#     namespace = kubernetes_namespace_v1.this[each.key].metadata.0.name
-#   }
-# }
+    name      = "${each.key}-workload-identity-sa"
+    namespace = kubernetes_namespace_v1.this[each.key].metadata.0.name
+  }
+}

--- a/regional/onboarding/main.tf
+++ b/regional/onboarding/main.tf
@@ -65,7 +65,7 @@ resource "kubernetes_role_v1" "namespace_admin" {
   }
 
   rule {
-    api_groups = [""]
+    api_groups = ["*"]
     resources  = ["*"]
     verbs      = ["create", "delete", "get", "list", "patch", "update", "watch"]
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new input parameter `node_location` to specify the zone for cluster nodes.
  - Added Kubernetes manifest resources for Istio configuration including destination rules, gateways, peer authentication, and virtual services.
  - Expanded configuration options for Istio VirtualServices.
  - Added version information for the `google` provider and new resources in the regional onboarding module.

- **Improvements**
  - Enhanced documentation with new README files and updated existing ones to reflect changes.

- **Bug Fixes**
  - Adjusted configurations and removed commented lines for various resources to improve clarity and functionality.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->