### PR TITLE
Support for 6.0.1 Terraform Google provider

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.92.1
+    rev: v1.92.3
     hooks:
       - id: terraform_fmt
 
@@ -29,7 +29,7 @@ repos:
       - id: terraform_docs
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.219
+    rev: 3.2.238
     hooks:
       - id: checkov
         verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.92.3
+    rev: v1.94.1
     hooks:
       - id: terraform_fmt
 
@@ -29,7 +29,7 @@ repos:
       - id: terraform_docs
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.238
+    rev: 3.2.239
     hooks:
       - id: checkov
         verbose: true

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.40.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.0.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
 
 ### Modules

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ terraform test
 
 > A child module automatically inherits default (un-aliased) provider configurations from its parent. The provider versions below are informational only and do **not** need to align with the provider configurations from its parent.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ### Requirements
 
 No requirements.
@@ -126,7 +126,7 @@ No modules.
 | <a name="output_container_deployer_service_accounts"></a> [container\_deployer\_service\_accounts](#output\_container\_deployer\_service\_accounts) | The service accounts for the container deployer |
 | <a name="output_gke_fleet_host_project_number"></a> [gke\_fleet\_host\_project\_number](#output\_gke\_fleet\_host\_project\_number) | The project number of the fleet host project |
 | <a name="output_workload_identity_service_account_emails"></a> [workload\_identity\_service\_account\_emails](#output\_workload\_identity\_service\_account\_emails) | The email addresses of the service accounts for the Kubernetes namespace workload identity |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 ## 📓 Terraform Regional Documentation
 

--- a/regional/README.md
+++ b/regional/README.md
@@ -2,7 +2,7 @@
 
 A child module automatically inherits its parent's default (un-aliased) provider configurations. The provider versions below are informational only and do **not** need to align with the provider configurations from its parent.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 No requirements.
@@ -74,4 +74,4 @@ No modules.
 | <a name="output_kms_key_ring_cluster_database_encryption_name"></a> [kms\_key\_ring\_cluster\_database\_encryption\_name](#output\_kms\_key\_ring\_cluster\_database\_encryption\_name) | The name of the Google Cloud KMS key ring |
 | <a name="output_project_id"></a> [project\_id](#output\_project\_id) | The ID of the project in which the resource belongs |
 | <a name="output_service_account_gke_operations_email"></a> [service\_account\_gke\_operations\_email](#output\_service\_account\_gke\_operations\_email) | The email address of the Kubernetes minimum privilege service account for the cluster |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/regional/README.md
+++ b/regional/README.md
@@ -11,8 +11,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.40.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 5.40.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.0.1 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 6.0.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
 
 ## Modules

--- a/regional/main.tf
+++ b/regional/main.tf
@@ -142,6 +142,7 @@ resource "google_container_cluster" "this" {
   monitoring_config {
     advanced_datapath_observability_config {
       enable_metrics = true
+      enable_relay   = false
     }
 
     enable_components = [

--- a/regional/onboarding/README.md
+++ b/regional/onboarding/README.md
@@ -11,8 +11,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.40.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.31.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.0.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.32.0 |
 
 ## Modules
 

--- a/regional/onboarding/README.md
+++ b/regional/onboarding/README.md
@@ -2,7 +2,7 @@
 
 > A child module automatically inherits default (un-aliased) provider configurations from its parent. The provider versions below are informational only and do **not** need to align with the provider configurations from its parent.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 No requirements.
@@ -41,4 +41,4 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_project_id"></a> [project\_id](#output\_project\_id) | The project ID |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a new configuration option for enhanced monitoring capabilities in the Google Kubernetes Engine, allowing users to disable relay functionality.

- **Updates**
	- Updated the version of the Google provider to 6.0.1, which may include enhancements and bug fixes.
	- Updated the version of the Kubernetes provider to 2.32.0, indicating potential improvements.
	- Incremented the version of the `pre-commit-terraform` and `checkov` tools to their latest versions, which may introduce performance improvements and new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->