### PR TITLE
Add istio-test namespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
       - id: checkov
         verbose: true
         args:
+          - --download-external-modules=true
           - --skip-check
           - "CKV_TF_1"
           - --quiet

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.14.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.16.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ### Modules

--- a/regional/README.md
+++ b/regional/README.md
@@ -11,7 +11,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.11.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.16.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ## Modules

--- a/regional/main.tf
+++ b/regional/main.tf
@@ -184,7 +184,14 @@ resource "google_container_cluster" "this" {
   # when it comes to POD scheduling and locality based load balancing.
 
   node_locations = module.helpers.zone != null ? ["${module.helpers.region}-${module.helpers.zone}"] : null
-  project        = var.project
+
+  node_pool_defaults {
+    node_config_defaults {
+      insecure_kubelet_readonly_port_enabled = "FALSE"
+    }
+  }
+
+  project = var.project
 
   release_channel {
     channel = var.release_channel
@@ -251,7 +258,6 @@ resource "google_container_node_pool" "this" {
     image_type        = each.value.image_type
 
     kubelet_config {
-      cpu_manager_policy                     = "none"
       insecure_kubelet_readonly_port_enabled = "FALSE"
     }
 
@@ -419,11 +425,7 @@ resource "google_kms_key_ring" "cluster_encryption" {
 
 resource "google_project_iam_member" "gke_operations" {
   for_each = toset([
-    "roles/autoscaling.metricsWriter",
-    "roles/logging.logWriter",
-    "roles/monitoring.metricWriter",
-    "roles/monitoring.viewer",
-    "roles/stackdriver.resourceMetadata.writer"
+    "roles/container.defaultNodeServiceAccount"
   ])
 
   member  = "serviceAccount:${google_service_account.gke_operations.email}"

--- a/regional/onboarding/README.md
+++ b/regional/onboarding/README.md
@@ -11,8 +11,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.11.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.33.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.16.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.35.1 |
 
 ## Modules
 

--- a/regional/onboarding/main.tf
+++ b/regional/onboarding/main.tf
@@ -19,6 +19,7 @@ resource "kubernetes_namespace_v1" "this" {
       "gatekeeper-system" = { istio_injection = "disabled" },
       "istio-ingress"     = { istio_injection = "enabled" },
       "istio-system"      = { istio_injection = "disabled" }
+      "istio-test"        = { istio_injection = "enabled" }
     }
   )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `istio-test` namespace with Istio injection enabled

- **Chores**
  - Updated Google provider version from 6.11.1 to 6.16.0 across multiple configuration files
  - Updated Kubernetes provider version from 2.33.0 to 2.35.1
  - Modified pre-commit hook configuration to download external modules

- **Configuration Updates**
  - Updated GKE cluster configuration with new node pool defaults
  - Simplified service account IAM roles for GKE operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->